### PR TITLE
Feature/tao 7390/use new api route for test takers api

### DIFF
--- a/actions/Api.php
+++ b/actions/Api.php
@@ -27,7 +27,7 @@ use oat\taoTestTaker\models\CrudService;
 
 /**
  * @deprecated
- * @see ApiV2
+ * @see RestTestTakers
  */
 class Api extends \tao_actions_CommonRestModule {
 

--- a/actions/RestTestTakers.php
+++ b/actions/RestTestTakers.php
@@ -92,12 +92,12 @@ class RestTestTakers extends \tao_actions_CommonRestModule
      *     @OA\Property(
      *         property="uiLg",
      *         type="string",
-     *         description="Interface language (uri or language code, 'fr-FR' for example)"
+     *         description="Interface language (uri or language code, 'fr-FR' or 'http://www.tao.lu/Ontologies/TAO.rdf#Langfr-FR' for example)"
      *     ),
      *     @OA\Property(
      *         property="defLg",
      *         type="string",
-     *         description="Default language (uri or language code, 'fr-FR' for example)"
+     *         description="Default language (uri or language code, 'fr-FR' or 'http://www.tao.lu/Ontologies/TAO.rdf#Langfr-FR' for example)"
      *     ),
      *     @OA\Property(
      *         property="firstName",

--- a/actions/RestTestTakers.php
+++ b/actions/RestTestTakers.php
@@ -44,7 +44,32 @@ use oat\taoTestTaker\models\CrudService;
  *     @OA\Response(
  *         response="200",
  *         description="Test taker created",
- *         @OA\JsonContent(ref="#/components/schemas/tao.CommonRestModule.CreatedResourceResponse")
+ *         @OA\MediaType(
+ *             mediaType="application/json",
+ *             @OA\Schema(
+ *                 type="object",
+ *                 @OA\Property(
+ *                     property="success",
+ *                     type="boolean",
+ *                     description="`false` on failure, `true` on success",
+ *                 ),
+ *                 @OA\Property(
+ *                     property="data",
+ *                     type="string",
+ *                     description="Created test center URI",
+ *                 ),
+ *                 @OA\Property(
+ *                     property="version",
+ *                     type="string",
+ *                     description="Platform version",
+ *                 ),
+ *                 example={
+ *                     "success": true,
+ *                     "data": "http://sample/first.rdf#i1536680377163171",
+ *                     "version": "3.3.0-sprint96"
+ *                 }
+ *             ),
+ *         ),
  *     ),
  *     @OA\Response(
  *         response="400",

--- a/actions/RestTestTakers.php
+++ b/actions/RestTestTakers.php
@@ -21,7 +21,11 @@
 
 namespace oat\taoTestTaker\actions;
 
+use Exception;
+use common_exception_RestApi;
+use common_exception_ValidationFailed;
 use oat\generis\model\OntologyRdf;
+use oat\generis\model\user\PasswordConstraintsException;
 use oat\generis\model\user\UserRdf;
 use oat\tao\model\TaoOntology;
 use oat\taoTestTaker\models\CrudService;
@@ -29,7 +33,7 @@ use oat\taoTestTaker\models\CrudService;
 /**
  * @OA\Info(title="TAO Test Taker API", version="2.0")
  * @OA\Post(
- *     path="/taoTestTaker/ApiV2",
+ *     path="/taoTestTaker/api/testTakers",
  *     summary="Create new test taker",
  *     @OA\RequestBody(
  *         @OA\MediaType(
@@ -50,7 +54,7 @@ use oat\taoTestTaker\models\CrudService;
  * )
  *
  */
-class ApiV2 extends \tao_actions_CommonRestModule
+class RestTestTakers extends \tao_actions_CommonRestModule
 {
     /**
      * @OA\Schema(
@@ -115,16 +119,23 @@ class ApiV2 extends \tao_actions_CommonRestModule
 
     const ROOT_CLASS = TaoOntology::CLASS_URI_SUBJECT;
 
-    public function __construct() {
+    public function __construct()
+    {
         parent::__construct();
         $this->service = CrudService::singleton();
+    }
+
+    public function index()
+    {
+        $this->returnFailure(new common_exception_RestApi('Not implemented.'));
     }
 
     /**
      * Optionally a specific rest controller may declare
      * aliases for parameters used for the rest communication
      */
-    protected function getParametersAliases(){
+    protected function getParametersAliases()
+    {
         return array_merge(parent::getParametersAliases(), [
             'login' => UserRdf::PROPERTY_LOGIN,
             'password' => UserRdf::PROPERTY_PASSWORD,
@@ -139,7 +150,8 @@ class ApiV2 extends \tao_actions_CommonRestModule
     /**
      * Optional Requirements for parameters to be sent on every service
      */
-    protected function getParametersRequirements() {
+    protected function getParametersRequirements()
+    {
         return [
             'post' => array("login", "password")
         ];
@@ -150,8 +162,9 @@ class ApiV2 extends \tao_actions_CommonRestModule
      * @return mixed
      * @throws \common_exception_NotImplemented
      */
-    protected function get($uri = null) {
-        throw new \common_exception_NotImplemented('Not implemented');
+    public function get($uri = null)
+    {
+        $this->returnFailure(new common_exception_RestApi('Not implemented.'));
     }
 
     /**
@@ -159,8 +172,23 @@ class ApiV2 extends \tao_actions_CommonRestModule
      * @return mixed
      * @throws \common_exception_NotImplemented
      */
-    protected function put($uri) {
-        throw new \common_exception_NotImplemented('Not implemented');
+    public function put($uri)
+    {
+        $this->returnFailure(new common_exception_RestApi('Not implemented.'));
+    }
+
+    public function post()
+    {
+        try {
+            $this->returnSuccess(parent::post());
+        } catch (PasswordConstraintsException $e) {
+            $this->returnFailure(new common_exception_RestApi($e->getMessage()));
+        } catch (common_exception_ValidationFailed $e) {
+            $alias = $this->reverseSearchAlias($e->getField());
+            $this->returnFailure(new common_exception_ValidationFailed($alias, null, $e->getCode()));
+        } catch (Exception $e) {
+            $this->returnFailure($e);
+        }
     }
 
     /**
@@ -168,8 +196,9 @@ class ApiV2 extends \tao_actions_CommonRestModule
      * @return mixed
      * @throws \common_exception_NotImplemented
      */
-    protected function delete($uri = null) {
-        throw new \common_exception_NotImplemented('Not implemented');
+    public function delete($uri = null)
+    {
+        $this->returnFailure(new common_exception_RestApi('Not implemented.'));
     }
 
     protected function getParameters()

--- a/actions/RestTestTakers.php
+++ b/actions/RestTestTakers.php
@@ -54,19 +54,13 @@ use oat\taoTestTaker\models\CrudService;
  *                     description="`false` on failure, `true` on success",
  *                 ),
  *                 @OA\Property(
- *                     property="data",
+ *                     property="uri",
  *                     type="string",
- *                     description="Created test center URI",
- *                 ),
- *                 @OA\Property(
- *                     property="version",
- *                     type="string",
- *                     description="Platform version",
+ *                     description="Created test taker URI",
  *                 ),
  *                 example={
  *                     "success": true,
- *                     "data": "http://sample/first.rdf#i1536680377163171",
- *                     "version": "3.3.0-sprint96"
+ *                     "uri": "http://sample/first.rdf#i1536680377163171"
  *                 }
  *             ),
  *         ),
@@ -208,7 +202,10 @@ class RestTestTakers extends \tao_actions_CommonRestModule
             /** @var \core_kernel_classes_Resource $testTakerResource */
             $testTakerResource = parent::post();
 
-            $this->returnSuccess($testTakerResource->getUri());
+            $this->returnSuccess([
+                'success' => true,
+                'uri' => $testTakerResource->getUri(),
+            ], false);
         } catch (PasswordConstraintsException $e) {
             $this->returnFailure(new common_exception_RestApi($e->getMessage()));
         } catch (common_exception_ValidationFailed $e) {

--- a/actions/RestTestTakers.php
+++ b/actions/RestTestTakers.php
@@ -180,7 +180,10 @@ class RestTestTakers extends \tao_actions_CommonRestModule
     public function post()
     {
         try {
-            $this->returnSuccess(parent::post());
+            /** @var \core_kernel_classes_Resource $testTakerResource */
+            $testTakerResource = parent::post();
+
+            $this->returnSuccess($testTakerResource->getUri());
         } catch (PasswordConstraintsException $e) {
             $this->returnFailure(new common_exception_RestApi($e->getMessage()));
         } catch (common_exception_ValidationFailed $e) {

--- a/doc/swagger.json
+++ b/doc/swagger.json
@@ -5,7 +5,7 @@
     "version": "2.0"
   },
   "paths": {
-    "/taoTestTaker/ApiV2": {
+    "/taoTestTaker/api/testTakers": {
       "post": {
         "summary": "Create new test taker",
         "requestBody": {

--- a/doc/swagger.json
+++ b/doc/swagger.json
@@ -80,11 +80,11 @@
             "type": "string"
           },
           "uiLg": {
-            "description": "Interface language (uri or language code, 'fr-FR' for example)",
+            "description": "Interface language (uri or language code, 'fr-FR' or 'http://www.tao.lu/Ontologies/TAO.rdf#Langfr-FR' for example)",
             "type": "string"
           },
           "defLg": {
-            "description": "Default language (uri or language code, 'fr-FR' for example)",
+            "description": "Default language (uri or language code, 'fr-FR' or 'http://www.tao.lu/Ontologies/TAO.rdf#Langfr-FR' for example)",
             "type": "string"
           },
           "firstName": {

--- a/doc/swagger.json
+++ b/doc/swagger.json
@@ -23,7 +23,26 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/tao.CommonRestModule.CreatedResourceResponse"
+                  "properties": {
+                    "success": {
+                      "description": "`false` on failure, `true` on success",
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "description": "Created test center URI",
+                      "type": "string"
+                    },
+                    "version": {
+                      "description": "Platform version",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "example": {
+                    "success": true,
+                    "data": "http://sample/first.rdf#i1536680377163171",
+                    "version": "3.3.0-sprint96"
+                  }
                 }
               }
             }

--- a/doc/swagger.json
+++ b/doc/swagger.json
@@ -28,8 +28,8 @@
                       "description": "`false` on failure, `true` on success",
                       "type": "boolean"
                     },
-                    "data": {
-                      "description": "Created test center URI",
+                    "uri": {
+                      "description": "Created test taker URI",
                       "type": "string"
                     },
                     "version": {
@@ -40,8 +40,7 @@
                   "type": "object",
                   "example": {
                     "success": true,
-                    "data": "http://sample/first.rdf#i1536680377163171",
-                    "version": "3.3.0-sprint96"
+                    "uri": "http://sample/first.rdf#i1536680377163171"
                   }
                 }
               }

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Test-taker core extension',
 	'description' => 'TAO TestTaker extension',
     'license' => 'GPL-2.0',
-    'version' => '4.2.2',
+    'version' => '5.0.0',
 	'author' => 'Open Assessment Technologies, CRP Henri Tudor',
 	'requires' => array(
 	    'tao' => '>=26.0.0',
@@ -57,6 +57,7 @@ return array(
         array('grant', 'http://www.tao.lu/Ontologies/TAOSubject.rdf#SubjectsManagerRole', array('ext'=>'taoTestTaker'))
     ),
     'routes' => array(
+        '/taoTestTaker/api' => ['class' => \oat\taoTestTaker\models\routing\ApiRoute::class],
         '/taoTestTaker' => 'oat\\taoTestTaker\\actions'
     ),
 	'constants' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,9 @@ return array(
 	'update' => "oat\\taoTestTaker\\scripts\\update\\Updater",
 	'managementRole' => 'http://www.tao.lu/Ontologies/TAOSubject.rdf#SubjectsManagerRole',
     'acl' => array(
-        array('grant', 'http://www.tao.lu/Ontologies/TAOSubject.rdf#SubjectsManagerRole', array('ext'=>'taoTestTaker'))
+        array('grant', 'http://www.tao.lu/Ontologies/TAOSubject.rdf#SubjectsManagerRole', array('ext'=>'taoTestTaker')),
+        array('grant', \oat\tao\model\user\TaoRoles::SYSTEM_ADMINISTRATOR, \oat\taoTestTaker\actions\RestTestTakers::class),
+        array('grant', \oat\tao\model\user\TaoRoles::GLOBAL_MANAGER, \oat\taoTestTaker\actions\RestTestTakers::class)
     ),
     'routes' => array(
         '/taoTestTaker/api' => ['class' => \oat\taoTestTaker\models\routing\ApiRoute::class],

--- a/manifest.php
+++ b/manifest.php
@@ -54,9 +54,7 @@ return array(
 	'update' => "oat\\taoTestTaker\\scripts\\update\\Updater",
 	'managementRole' => 'http://www.tao.lu/Ontologies/TAOSubject.rdf#SubjectsManagerRole',
     'acl' => array(
-        array('grant', 'http://www.tao.lu/Ontologies/TAOSubject.rdf#SubjectsManagerRole', array('ext'=>'taoTestTaker')),
-        array('grant', \oat\tao\model\user\TaoRoles::SYSTEM_ADMINISTRATOR, \oat\taoTestTaker\actions\RestTestTakers::class),
-        array('grant', \oat\tao\model\user\TaoRoles::GLOBAL_MANAGER, \oat\taoTestTaker\actions\RestTestTakers::class)
+        array('grant', \oat\taoTestTaker\models\TestTakerService::ROLE_SUBJECT_MANAGER, array('ext'=>'taoTestTaker'))
     ),
     'routes' => array(
         '/taoTestTaker/api' => ['class' => \oat\taoTestTaker\models\routing\ApiRoute::class],

--- a/models/TestTakerService.php
+++ b/models/TestTakerService.php
@@ -43,6 +43,8 @@ class TestTakerService extends \tao_models_classes_ClassService
 
     const CLASS_URI_SUBJECT = 'http://www.tao.lu/Ontologies/TAOSubject.rdf#Subject';
 
+    const ROLE_SUBJECT_MANAGER = 'http://www.tao.lu/Ontologies/TAOSubject.rdf#SubjectsManagerRole';
+
     protected $subjectClass = null;
 
     /**

--- a/models/routing/ApiRoute.php
+++ b/models/routing/ApiRoute.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoTestTaker\models\routing;
+
+use oat\tao\model\routing\AbstractApiRoute;
+
+class ApiRoute extends AbstractApiRoute
+{
+    const REST_CONTROLLER_PREFIX = 'oat\\taoTestTaker\\actions\\Rest';
+
+    /**
+     * @inheritdoc
+     */
+    protected function getControllerPrefix()
+    {
+        return self::REST_CONTROLLER_PREFIX;
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -97,13 +97,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $extension->setConfig('csvImporterCallbacks', $config);
             $this->setVersion('3.11.0');
         }
-        $this->skip('3.11.0', '4.2.2');
 
-        if ($this->isVersion('4.2.2')) {
-            AclProxy::applyRule(new AccessRule(AccessRule::GRANT,  TaoRoles::SYSTEM_ADMINISTRATOR, RestTestTakers::class));
-            AclProxy::applyRule(new AccessRule(AccessRule::GRANT,  TaoRoles::GLOBAL_MANAGER, RestTestTakers::class));
-
-            $this->setVersion('5.0.0');
-        }
+        $this->skip('3.11.0', '5.0.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -27,7 +27,9 @@ use oat\tao\model\accessControl\func\AccessRule;
 use oat\tao\model\user\TaoRoles;
 use oat\taoTestTaker\actions\Api;
 use oat\tao\model\user\import\UserCsvImporterFactory;
+use oat\taoTestTaker\actions\RestTestTakers;
 use oat\taoTestTaker\models\TestTakerImporter;
+use oat\taoTestTaker\models\TestTakerService;
 
 /**
  * Class Updater
@@ -97,5 +99,11 @@ class Updater extends \common_ext_ExtensionUpdater
         }
         $this->skip('3.11.0', '4.2.2');
 
+        if ($this->isVersion('4.2.2')) {
+            AclProxy::applyRule(new AccessRule(AccessRule::GRANT,  TaoRoles::SYSTEM_ADMINISTRATOR, RestTestTakers::class));
+            AclProxy::applyRule(new AccessRule(AccessRule::GRANT,  TaoRoles::GLOBAL_MANAGER, RestTestTakers::class));
+
+            $this->setVersion('5.0.0');
+        }
     }
 }


### PR DESCRIPTION
Move test takers API under new API router
