### PR TITLE
Fix parameter mismatch in editSubject form

### DIFF
--- a/actions/TestTaker.php
+++ b/actions/TestTaker.php
@@ -145,7 +145,6 @@ class TestTaker extends tao_actions_SaSModule
             $clazz,
             $subject,
             $addMode,
-            false,
             [FormContainer::CSRF_PROTECTION_OPTION => true]
         );
         $myForm = $myFormContainer->getForm();

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Test-taker core extension',
 	'description' => 'TAO TestTaker extension',
     'license' => 'GPL-2.0',
-    'version' => '7.0.0',
+    'version' => '7.0.1',
 	'author' => 'Open Assessment Technologies, CRP Henri Tudor',
 	'requires' => array(
 	    'tao' => '>=34.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -98,6 +98,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('3.11.0');
         }
 
-        $this->skip('3.11.0', '7.0.0');
+        $this->skip('3.11.0', '7.0.1');
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7306

In taoTestTaker, the edit form was being rendered without a hidden CSRF token. After this small change, the token will be included and the form will submit.