### PR TITLE
TAO-8629 - The TestTakerService has been refactored. Unit tests are a…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Test-taker core extension',
 	'description' => 'TAO TestTaker extension',
     'license' => 'GPL-2.0',
-    'version' => '7.1.1',
+    'version' => '7.1.2',
 	'author' => 'Open Assessment Technologies, CRP Henri Tudor',
 	'requires' => array(
 	    'tao' => '>=36.1.0',

--- a/models/TestTakerService.php
+++ b/models/TestTakerService.php
@@ -30,6 +30,7 @@ use oat\taoTestTaker\models\events\TestTakerClassCreatedEvent;
 use oat\taoTestTaker\models\events\TestTakerClassRemovedEvent;
 use oat\taoTestTaker\models\events\TestTakerCreatedEvent;
 use oat\taoTestTaker\models\events\TestTakerRemovedEvent;
+use oat\tao\model\OntologyClassService;
 
 /**
  * Service methods to manage the Subjects business models using the RDF API.
@@ -37,7 +38,7 @@ use oat\taoTestTaker\models\events\TestTakerRemovedEvent;
  * @access public
  * @author Joel Bout, <joel.bout@tudor.lu>
  */
-class TestTakerService extends \tao_models_classes_ClassService
+class TestTakerService extends OntologyClassService
 {
     use EventManagerAwareTrait;
 
@@ -45,23 +46,12 @@ class TestTakerService extends \tao_models_classes_ClassService
 
     const ROLE_SUBJECT_MANAGER = 'http://www.tao.lu/Ontologies/TAOSubject.rdf#SubjectsManagerRole';
 
-    protected $subjectClass = null;
-
-    /**
-     * TestTakerService constructor.
-     */
-    public function __construct()
-    {
-        parent::__construct();
-        $this->subjectClass = new \core_kernel_classes_Class(TaoOntology::SUBJECT_CLASS_URI);
-    }
-
     /**
      * @return core_kernel_classes_Class|null
      */
     public function getRootClass()
     {
-        return $this->subjectClass;
+        return $this->getClass(TaoOntology::SUBJECT_CLASS_URI);
     }
 
     /**
@@ -146,10 +136,10 @@ class TestTakerService extends \tao_models_classes_ClassService
     {
         $returnValue = (bool) false;
 
-        if ($clazz->getUri() == $this->subjectClass->getUri()) {
+        if ($clazz->getUri() == $this->getRootClass()->getUri()) {
             $returnValue = true;
         } else {
-            foreach ($this->subjectClass->getSubClasses(true) as $subclass) {
+            foreach ($this->getRootClass()->getSubClasses(true) as $subclass) {
                 if ($clazz->getUri() == $subclass->getUri()) {
                     $returnValue = true;
                     break;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -98,6 +98,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('3.11.0');
         }
 
-        $this->skip('3.11.0', '7.1.1');
+        $this->skip('3.11.0', '7.1.2');
     }
 }

--- a/test/integration/TestTakerTest.php
+++ b/test/integration/TestTakerTest.php
@@ -22,6 +22,7 @@
 
 namespace oat\taoTestTaker\test\integration;
 
+use oat\tao\model\OntologyClassService;
 use oat\tao\model\TaoOntology;
 use oat\generis\model\GenerisRdf;
 use oat\generis\model\OntologyRdfs;
@@ -29,7 +30,6 @@ use oat\tao\test\TaoPhpUnitTestRunner;
 use oat\taoTestTaker\models\TestTakerService;
 use core_kernel_classes_Resource;
 use core_kernel_classes_Class;
-use tao_models_classes_Service;
 
 
 /**
@@ -65,7 +65,7 @@ class TestTakerTest extends TaoPhpUnitTestRunner
      */
     public function testService()
     {
-        $this->assertIsA($this->subjectsService, tao_models_classes_Service::class);
+        $this->assertIsA($this->subjectsService, OntologyClassService::class);
         $this->assertIsA($this->subjectsService, TestTakerService::class);
     }
 

--- a/test/unit/models/TestTakerServiceTest.php
+++ b/test/unit/models/TestTakerServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+use oat\generis\test\TestCase;
+use oat\tao\model\TaoOntology;
+use oat\taoTestTaker\models\TestTakerService;
+
+class TestTakerServiceTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function testGetRootClass()
+    {
+        $service = new TestTakerService();
+        $this->assertInstanceOf(core_kernel_classes_Class::class, $service->getRootClass());
+    }
+}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8629

All classes extend the class `tao_models_classes_ClassService` are unit testable and now extend OntologyClassService class

`__construct()` methods of the classes are empty

All classes directly or indirectly extending `tao_models_classes_ClassService` do not have a custom constructor

The behaviour of the modified classes remains unchanged
The TAO platform still continue to behave as it was

