### PR TITLE
TAO-8697 - Replace Calls of singleton method by ServiceManager calls

### DIFF
--- a/models/TestTakerService.php
+++ b/models/TestTakerService.php
@@ -31,6 +31,7 @@ use oat\taoTestTaker\models\events\TestTakerClassRemovedEvent;
 use oat\taoTestTaker\models\events\TestTakerCreatedEvent;
 use oat\taoTestTaker\models\events\TestTakerRemovedEvent;
 use oat\tao\model\OntologyClassService;
+use tao_models_classes_UserService as UserService;
 
 /**
  * Service methods to manage the Subjects business models using the RDF API.
@@ -179,7 +180,7 @@ class TestTakerService extends OntologyClassService
         $login = $instance->getUniquePropertyValue($loginProperty);
         
         $returnValue = parent::cloneInstance($instance, $clazz);
-        $userService = \tao_models_classes_UserService::singleton();
+        $userService = $this->getServiceLocator()->get(UserService::SERVICE_ID);
         try {
             while ($userService->loginExists($login)) {
                 $login .= (string) rand(0, 9);

--- a/test/integration/TestTakerTest.php
+++ b/test/integration/TestTakerTest.php
@@ -30,7 +30,8 @@ use oat\tao\test\TaoPhpUnitTestRunner;
 use oat\taoTestTaker\models\TestTakerService;
 use core_kernel_classes_Resource;
 use core_kernel_classes_Class;
-
+use oat\generis\test\TestCase;
+use oat\taoLti\models\classes\user\UserService as UserService;
 
 /**
  * @author Bertrand Chevrier, <taosupport@tudor.lu>
@@ -52,9 +53,14 @@ class TestTakerTest extends TaoPhpUnitTestRunner
     public function setUp()
     {
         TaoPhpUnitTestRunner::initTest();
-        // load constants
-        \common_ext_ExtensionsManager::singleton()->getExtensionById('taoTestTaker');
-        $this->subjectsService = new TestTakerService();
+
+        $testTakerService = new TestTakerService();
+        $userService = new UserService();
+        $serviceLocatorMock = $this->getServiceLocatorMock([
+            UserService::SERVICE_ID => $userService,
+        ]);
+        $testTakerService->setServiceLocator($serviceLocatorMock);
+        $this->subjectsService = $testTakerService;
     }
 
     /**


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8697
Replace Calls of singleton method by ServiceManager calls

Classes which are extending the OntologyClass ConfigurableService, are retrieved by using the ServiceManager::get() method instead of calling the deprecated singleton method.