### PR TITLE
remove taoGroups dependency

### DIFF
--- a/actions/TestTaker.php
+++ b/actions/TestTaker.php
@@ -34,11 +34,11 @@ use oat\generis\model\GenerisRdf;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\event\EventManager;
 use oat\tao\model\resources\ResourceWatcher;
-use oat\tao\model\routing\AnnotationReader\security;
 use oat\taoTestTaker\actions\form\Search;
 use oat\taoTestTaker\actions\form\TestTaker as TestTakerForm;
 use oat\taoGroups\helpers\TestTakerForm as GroupForm;
 use oat\taoTestTaker\models\events\TestTakerUpdatedEvent;
+use oat\taoTestTaker\models\TestTakerFormService;
 use oat\taoTestTaker\models\TestTakerService;
 use tao_actions_SaSModule;
 use tao_helpers_Uri;
@@ -214,11 +214,9 @@ class TestTaker extends tao_actions_SaSModule
             $this->setData('message', $message);
             $this->setData('reload', true);
         }
-
-        if (common_ext_ExtensionsManager::singleton()->isEnabled('taoGroups')) {
-            $this->setData('groupForm', GroupForm::renderGroupTreeForm($subject));
-        }
-        $updatedAt = $this->getServiceManager()->get(ResourceWatcher::SERVICE_ID)->getUpdatedAt($subject);
+        $testTakerFormService = $this->getServiceLocator()->get(TestTakerFormService::SERVICE_ID);
+        $this->setData('additionalForms', $testTakerFormService->renderAdditionalForms($subject));
+        $updatedAt = $this->getServiceLocator()->get(ResourceWatcher::SERVICE_ID)->getUpdatedAt($subject);
         $this->setData('updatedAt', $updatedAt);
         $this->setData('checkLogin', $addMode);
         $this->setData('formTitle', __('Edit subject'));

--- a/config/default/TestTakerFormService.conf.php
+++ b/config/default/TestTakerFormService.conf.php
@@ -1,0 +1,3 @@
+<?php
+
+return new oat\taoTestTaker\models\TestTakerFormService();

--- a/manifest.php
+++ b/manifest.php
@@ -40,7 +40,7 @@ return [
     'label' => 'Test-taker core extension',
     'description' => 'TAO TestTaker extension',
     'license' => 'GPL-2.0',
-    'version' => '7.7.3',
+    'version' => '7.8.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.15.0',

--- a/migrations/Version202011231248193148_taoTestTaker.php
+++ b/migrations/Version202011231248193148_taoTestTaker.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoTestTaker\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoTestTaker\models\TestTakerFormService;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202011231248193148_taoTestTaker extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Register TestTakerFormService';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->registerService(TestTakerFormService::SERVICE_ID, new TestTakerFormService());
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->getServiceManager()->unregister(TestTakerFormService::SERVICE_ID);
+    }
+}

--- a/models/TestTakerFormService.php
+++ b/models/TestTakerFormService.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoTestTaker\models;
+
+use oat\oatbox\service\ConfigurableService;
+
+/**
+ * Class TestTakerFormService
+ * @package oat\taoTestTaker\models
+ */
+class TestTakerFormService extends ConfigurableService
+{
+    const SERVICE_ID = 'taoTestTaker/TestTakerFormService';
+    const OPTION_ADDITIONAL_FORM_PROPERTIES = 'additional_form_properties';
+
+    /**
+     * @param \core_kernel_classes_Resource $subject
+     * @return array
+     */
+    public function renderAdditionalForms(\core_kernel_classes_Resource $subject): array
+    {
+        $forms = [];
+        $props = $this->getOption(self::OPTION_ADDITIONAL_FORM_PROPERTIES) ?? [];
+        foreach ($props as $propUri) {
+            $property = new \core_kernel_classes_Property($propUri);
+            $groupForm = \tao_helpers_form_GenerisTreeForm::buildTree($subject, $property);
+            $groupForm->setData('title', __('Add to group'));
+            $forms[] = $groupForm->render();
+        }
+        return $forms;
+    }
+}

--- a/models/TestTakerFormService.php
+++ b/models/TestTakerFormService.php
@@ -46,7 +46,6 @@ class TestTakerFormService extends ConfigurableService
         foreach ($props as $propUri) {
             $property = new \core_kernel_classes_Property($propUri);
             $groupForm = \tao_helpers_form_GenerisTreeForm::buildTree($subject, $property);
-            $groupForm->setData('title', __('Add to group'));
             $forms[] = $groupForm->render();
         }
         return $forms;

--- a/views/templates/form_subjects.tpl
+++ b/views/templates/form_subjects.tpl
@@ -15,10 +15,11 @@ Template::inc('form_context.tpl', 'tao');
         <?=get_data('myForm')?>
     </div>
 </div>
-  
-<div class="data-container-wrapper flex-container-remainder">
-    <?=get_data('groupForm')?>
-</div>
+<?php foreach(get_data('additionalForms') as $additionalForm): ?>
+    <div class="data-container-wrapper flex-container-remainder">
+        <?= $additionalForm ?>
+    </div>
+<?php endforeach; ?>
 
 <?php if(get_data('checkLogin')):?>
 	<script>


### PR DESCRIPTION
Tao test takers extension depends on taoGroups (and vice versa).
Cycling dependency should be removed.

depends on: https://github.com/oat-sa/extension-tao-group/pull/133