### PR TITLE
Fix/RO-549/problem importing rdf

### DIFF
--- a/config/default/rdfImporterConfig.conf.php
+++ b/config/default/rdfImporterConfig.conf.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Default config header created during install
+ */
+
+return new oat\oatbox\config\ConfigurationService(array(
+    'strategy' => 'fail'
+));

--- a/config/default/rdfImporterConfig.conf.php
+++ b/config/default/rdfImporterConfig.conf.php
@@ -1,5 +1,7 @@
 <?php
 
+use oat\taoTestTaker\models\RdfImporter;
+
 return new oat\oatbox\config\ConfigurationService(array(
-    'strategy' => 'fail'
+    RdfImporter::OPTION_STRATEGY => RdfImporter::OPTION_STRATEGY_FAIL_ON_DUPLICATE
 ));

--- a/config/default/rdfImporterConfig.conf.php
+++ b/config/default/rdfImporterConfig.conf.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * Default config header created during install
- */
 
 return new oat\oatbox\config\ConfigurationService(array(
     'strategy' => 'fail'


### PR DESCRIPTION
Ticket: [RO-549](https://oat-sa.atlassian.net/browse/RO-549)

The goal of this PR is to create the missing config file during the extension install. This file is needed to define the strategy to be used during RDF import process