### PR TITLE
Fix/RO-576/config creation on install

### DIFF
--- a/config/default/rdfImporterConfig.conf.php
+++ b/config/default/rdfImporterConfig.conf.php
@@ -1,0 +1,7 @@
+<?php
+
+use oat\taoTestTaker\models\RdfImporter;
+
+return new oat\oatbox\config\ConfigurationService(array(
+    RdfImporter::OPTION_STRATEGY => RdfImporter::OPTION_STRATEGY_FAIL_ON_DUPLICATE
+));


### PR DESCRIPTION
Backport:

- Fix [RO-576](https://oat-sa.atlassian.net/browse/RO-576): Create default config for RDF import during install. Original Fix: #197