### PR TITLE
Fix/oatsd 2979/enforce testtaker def lang

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,41 @@
+name: Sonarqube_CI
+on:
+
+  push:
+    branches:
+      - master
+      - main
+      - develop
+
+  pull_request: 
+    types: [opened, synchronize, reopened]
+    branches: 
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Sonarqube_CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Sonarqube scan
+        uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+      # Job will fail when the Quality Gate is red
+      - name: Sonarqube quality gate check
+        id: sonarqube-quality-gate-check      
+        uses: sonarsource/sonarqube-quality-gate-action@master
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+
+      - name: "Example show SonarQube Quality Gate Status value"
+        run: echo "The Quality Gate status is ${{ steps.sonarqube-quality-gate-check.outputs.quality-gate-status }}"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.projectKey=extension-tao-testtaker


### PR DESCRIPTION
**Description**
The goal of this PR is to enforce the default language to be the same as UI language
/!\ Actually the behavior is by default, shall configure it only ignite customers, or only for infosign customers?

**Ticket**
https://oat-sa.atlassian.net/browse/OATSD-2979