### PR TITLE
fix: correct action bar icon order weights (AUT-4491)

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -18,43 +18,43 @@
                         />
                 </trees>
                 <actions allowClassActions="true">
-                    <action id="testtaker-class-properties" name="Properties" url="/taoTestTaker/TestTaker/editClassLabel" group="content" context="class">
+                    <action id="testtaker-class-properties" name="Properties" url="/taoTestTaker/TestTaker/editClassLabel" group="content" context="class" weight="10">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="testtaker-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class">
+                    <action id="testtaker-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="3">
                         <icon id="icon-property-add"/>
                     </action>
-                    <action id="testtaker-properties" name="Properties"  url="/taoTestTaker/TestTaker/editSubject" group="content" context="instance">
+                    <action id="testtaker-properties" name="Properties"  url="/taoTestTaker/TestTaker/editSubject" group="content" context="instance" weight="10">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="testtaker-class-new" name="New class" url="/taoTestTaker/TestTaker/addSubClass" context="resource" group="tree" binding="subClass" weight="10">
                         <icon id="icon-folder-open"/>
                     </action>
-                    <action id="testtaker-delete" name="Delete" url="/taoTestTaker/TestTaker/delete" context="resource" group="tree" binding="removeNode" weight="-1">
+                    <action id="testtaker-delete" name="Delete" url="/taoTestTaker/TestTaker/delete" context="resource" group="tree" binding="removeNode" weight="9">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="testtaker-delete-all" name="Delete" url="/taoTestTaker/TestTaker/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="-2">
+                    <action id="testtaker-delete-all" name="Delete" url="/taoTestTaker/TestTaker/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="9">
                         <icon id="icon-bin"/>
                     </action>
                     <action id="testtaker-move" name="Move" url="/taoTestTaker/TestTaker/moveInstance" context="instance" group="none" binding="moveNode">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="testtaker-move-to" name="Move To" url="/taoTestTaker/TestTaker/moveResource" context="instance" group="tree" binding="moveTo">
+                    <action id="testtaker-move-to" name="Move To" url="/taoTestTaker/TestTaker/moveResource" context="instance" group="tree" binding="moveTo" weight="4">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="class-move-to" name="Move To" url="/taoTestTaker/TestTaker/moveClass" context="class" group="tree" binding="moveTo" weight="8">
+                    <action id="class-move-to" name="Move To" url="/taoTestTaker/TestTaker/moveClass" context="class" group="tree" binding="moveTo" weight="4">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="testtaker-move-all" name="Move To" url="/taoTestTaker/TestTaker/moveAll" context="resource" multiple="true" group="tree" binding="moveTo">
+                    <action id="testtaker-move-all" name="Move To" url="/taoTestTaker/TestTaker/moveAll" context="resource" multiple="true" group="tree" binding="moveTo" weight="4">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="testtaker-import" name="Import" url="/taoTestTaker/Import/index" context="resource" group="tree" weight="7">
+                    <action id="testtaker-import" name="Import" url="/taoTestTaker/Import/index" context="resource" group="tree" weight="8">
                         <icon id="icon-import"/>
                     </action>
-                    <action id="testtaker-export" name="Export" url="/taoTestTaker/Export/index" context="resource" group="tree" weight="6">
+                    <action id="testtaker-export" name="Export" url="/taoTestTaker/Export/index" context="resource" group="tree" weight="7">
                         <icon id="icon-export"/>
                     </action>
-                    <action id="testtaker-new" name="New test-taker" url="/taoTestTaker/TestTaker/addInstance" context="resource" group="tree" binding="instanciate" weight="9">
+                    <action id="testtaker-new" name="New test-taker" url="/taoTestTaker/TestTaker/addInstance" context="resource" group="tree" binding="instanciate" weight="1">
                         <icon id="icon-test-taker"/>
                     </action>
                 </actions>

--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -18,13 +18,13 @@
                         />
                 </trees>
                 <actions allowClassActions="true">
-                    <action id="testtaker-class-properties" name="Properties" url="/taoTestTaker/TestTaker/editClassLabel" group="content" context="class" weight="10">
+                    <action id="testtaker-class-properties" name="Properties" url="/taoTestTaker/TestTaker/editClassLabel" group="content" context="class" weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="testtaker-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="3">
+                    <action id="testtaker-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="8">
                         <icon id="icon-property-add"/>
                     </action>
-                    <action id="testtaker-properties" name="Properties"  url="/taoTestTaker/TestTaker/editSubject" group="content" context="instance" weight="10">
+                    <action id="testtaker-properties" name="Properties"  url="/taoTestTaker/TestTaker/editSubject" group="content" context="instance" weight="1">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="testtaker-class-new" name="New class" url="/taoTestTaker/TestTaker/addSubClass" context="resource" group="tree" binding="subClass" weight="10">


### PR DESCRIPTION
# fix: correct action bar icon order weights (AUT-4491)

## Summary

- Adds missing `weight` attributes to all action definitions in `structures.xml` files across affected extensions.
- Fixes incorrect icon order in the Actions menu (all tabs) when the QuickWins design feature flag is enabled.
- Root cause: `getSortedActionsByWeight()` in `tao/helpers/Layout.php` sorts ascending by weight; weights were never consistently set when weight-based sorting was introduced in AUT-3938.

## Weight conventions applied

### Tree actions (lower = leftmost)
| Weight | Action type |
|--------|------------|
| 10 | New class |
| 9 | Delete (instance / class / all) |
| 8 | Import |
| 7 | Export / Publish |
| 6 | Duplicate |
| 5 | Copy To |
| 4 | Move To |
| 3 | Translate |
| 1 | New [entity] (primary create action) |

### Content actions
| Weight | Action type |
|--------|------------|
| 10 | Properties (instance / class) |
| 9 | Preview |
| 8 | Authoring |
| 7 | History |
| 6 | Usage |
| 5 | Item Statistics |
| 3 | Manage Schema |

## Impacted extensions

- `extension-tao-item` (taoItems)
- `extension-tao-itemqti` (taoQtiItem)
- `extension-tao-test` (taoTests)
- `extension-tao-testqti` (taoQtiTest)
- `extension-tao-group` (taoGroups)
- `extension-tao-testtaker` (taoTestTaker)
- `extension-tao-delivery-rdf` (taoDeliveryRdf)
- `extension-tao-deliver-connect` (taoDeliverConnect)
- `extension-tao-backoffice` (taoBackOffice)
- `extension-tao-outcomeui` (taoOutcomeUi)
- `extension-tao-proctoring` (taoProctoring)
- `extension-remote-proctoring` (remoteProctoring)
- `extension-tao-lti-consumer` (taoLtiConsumer)
- `extension-tao-testcenter` (taoTestCenter)
- `extension-tao-blueprints` (taoBlueprints)
- `extension-tao-mediamanager` (taoMediaManager)

## Testing

Enable the QuickWins design feature flag and verify the Actions toolbar icons appear in the correct order on all tabs (Items, Tests, Test-Takers, Groups, Deliveries, Results, Assets, Blueprints, Test Centers).

No code logic changes — XML `weight` attribute additions/corrections only.

## Related

- Jira: AUT-4491
- Introduced by: AUT-3938 (weight-based sort added to Layout.php)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted action priorities in the test-taker interface to change menu ordering and visibility:
    * Delete actions promoted to higher priority for more prominence.
    * "New" action moved to lower priority.
    * Move, import, and export actions reprioritized for improved grouping.
    * Properties and schema actions repositioned to better reflect workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->