### PR TITLE
fix: reorder tree actions for AUT-4491

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -27,34 +27,34 @@
                     <action id="testtaker-properties" name="Properties"  url="/taoTestTaker/TestTaker/editSubject" group="content" context="instance" weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="testtaker-class-new" name="New class" url="/taoTestTaker/TestTaker/addSubClass" context="resource" group="tree" binding="subClass" weight="10">
+                    <action id="testtaker-class-new" name="New class" url="/taoTestTaker/TestTaker/addSubClass" context="resource" group="tree" binding="subClass" weight="1">
                         <icon id="icon-folder-open"/>
                     </action>
-                    <action id="testtaker-delete" name="Delete" url="/taoTestTaker/TestTaker/delete" context="resource" group="tree" binding="removeNode" weight="9">
+                    <action id="testtaker-delete" name="Delete" url="/taoTestTaker/TestTaker/delete" context="resource" group="tree" binding="removeNode" weight="2">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="testtaker-delete-all" name="Delete" url="/taoTestTaker/TestTaker/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="9">
+                    <action id="testtaker-delete-all" name="Delete" url="/taoTestTaker/TestTaker/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="2">
                         <icon id="icon-bin"/>
                     </action>
                     <action id="testtaker-move" name="Move" url="/taoTestTaker/TestTaker/moveInstance" context="instance" group="none" binding="moveNode">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="testtaker-move-to" name="Move To" url="/taoTestTaker/TestTaker/moveResource" context="instance" group="tree" binding="moveTo" weight="4">
+                    <action id="testtaker-move-to" name="Move To" url="/taoTestTaker/TestTaker/moveResource" context="instance" group="tree" binding="moveTo" weight="3">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="class-move-to" name="Move To" url="/taoTestTaker/TestTaker/moveClass" context="class" group="tree" binding="moveTo" weight="4">
+                    <action id="class-move-to" name="Move To" url="/taoTestTaker/TestTaker/moveClass" context="class" group="tree" binding="moveTo" weight="3">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="testtaker-move-all" name="Move To" url="/taoTestTaker/TestTaker/moveAll" context="resource" multiple="true" group="tree" binding="moveTo" weight="4">
+                    <action id="testtaker-move-all" name="Move To" url="/taoTestTaker/TestTaker/moveAll" context="resource" multiple="true" group="tree" binding="moveTo" weight="3">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="testtaker-import" name="Import" url="/taoTestTaker/Import/index" context="resource" group="tree" weight="8">
+                    <action id="testtaker-import" name="Import" url="/taoTestTaker/Import/index" context="resource" group="tree" weight="4">
                         <icon id="icon-import"/>
                     </action>
-                    <action id="testtaker-export" name="Export" url="/taoTestTaker/Export/index" context="resource" group="tree" weight="7">
+                    <action id="testtaker-export" name="Export" url="/taoTestTaker/Export/index" context="resource" group="tree" weight="5">
                         <icon id="icon-export"/>
                     </action>
-                    <action id="testtaker-new" name="New test-taker" url="/taoTestTaker/TestTaker/addInstance" context="resource" group="tree" binding="instanciate" weight="1">
+                    <action id="testtaker-new" name="New test-taker" url="/taoTestTaker/TestTaker/addInstance" context="resource" group="tree" binding="instanciate" weight="6">
                         <icon id="icon-test-taker"/>
                     </action>
                 </actions>


### PR DESCRIPTION
## Summary

Adjust tree action weights in Test Takers to enforce the expected Tree Actions order for AUT-4491.

## Changes

- Updated `taoTestTaker/actions/structures.xml` action weights for `group="tree"`.
- Final order:
  - New class
  - Delete
  - Move To
  - Import
  - Export
  - New test-taker
  - Access Control (provided by `taoDacSimple`)

## Validation

- Open **Test Takers** tree and verify action order in the action bar.

## Risk

Low. XML weight-only ordering change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered management actions in the TestTaker interface to improve workflow and usability by prioritizing frequently used operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->